### PR TITLE
chore: link correctly to 30DaysOfJavaScript repository

### DIFF
--- a/readMe.md
+++ b/readMe.md
@@ -73,7 +73,7 @@ React can do everything that JavaScript can do. React can be used **_to add inte
 I believe you will learn quite a lot in the next 30 days and your programming and problem solving skills will also be improved significantly.
 
 I will use conversational English and less jargons to write this challenge. The content will be continuously updated. If you find a typo or grammar mistakes don't surprised because I don't do any proof read before I publish it. I would recommend you to focus on the main message of the challenge instead of the English and some minor mistakes. I really appreciate if you send me pull requests for improvement and remember to pull first from master before you send pull requests. Most of the images I have used in this challenge came from 30DaysOfJavaScript challenge therefore you may need to rename file names and folders 30DaysOfReact.
-If you are good at arrays, loops, functions, objects, functional programming, destructuring and spreading and class then you will be able to follow the challenge properly. Otherwise, I strongly recommend you to check [30DaysOfJavaScript](https://github.com/Asabeneh/30-Days-Of-React).
+If you are good at arrays, loops, functions, objects, functional programming, destructuring and spreading and class then you will be able to follow the challenge properly. Otherwise, I strongly recommend you to check [30DaysOfJavaScript](https://github.com/Asabeneh/30-Days-Of-JavaScript).
 
 ## Requirements
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55793353/95034685-8f223700-06ba-11eb-90ac-6a78f89942c6.png)
30DaysOfJavaScript currently links to 30DaysOfReact repo instead of 30DaysOfJavaScript

Correctly link it to 30DaysOfJavaScript 