### PR TITLE
Fix React identifier typo

### DIFF
--- a/26_Context/26_context_boilerplate/src/index.js
+++ b/26_Context/26_context_boilerplate/src/index.js
@@ -10,7 +10,7 @@ const Country = ({ country: { name, flag, population } }) => {
         <img src={flag} alt={name} />
       </div>
       <h3 className='country_name'>{name.toUpperCase()}</h3>
-      <div class='country_text'>
+      <div className='country_text'>
         <p>
           <span>Population: </span>
           {population}


### PR DESCRIPTION
React identifier typo: change class to className.