### PR TITLE
Fixed button Tag on day 11 HTML Example

### DIFF
--- a/11_Day_Events/11_events.md
+++ b/11_Day_Events/11_events.md
@@ -48,7 +48,7 @@ Event handling in HTML
     <title>30 Days Of React App</title>
   </head>
   <body>
-    <button>onclick="greetPeople()">Greet People</button>
+    <button onclick="greetPeople()">Greet People</button>
     <script>
       const greetPeople = () => {
         alert('Welcome to 30 Days Of React Challenge')


### PR DESCRIPTION
The HTML button example would not work because the button tag was being closed before the onclick="greetPeople()" part. Might be confusing for beginners trying to follow along.