### PR TITLE
Fix link rendering for Day 19 Projects

### DIFF
--- a/19_projects/19_projects.md
+++ b/19_projects/19_projects.md
@@ -30,7 +30,7 @@ Congratulations for making it to this far. Now, you have a solid understanding o
 
 ## Exercises: Level 1
 
-Use the following two APIs, [all cats](https://api.thecatapi.com/v1/breeds) and [a single cat][https://api.thecatapi.com/v1/images/search?breed_id=abys]. In the single cat API, you can get url property which is the image of the cat.
+Use the following two APIs, [all cats](https://api.thecatapi.com/v1/breeds) and [a single cat](https://api.thecatapi.com/v1/images/search?breed_id=abys). In the single cat API, you can get url property which is the image of the cat.
 Your result should look like this [demo](https://www.30daysofreact.com/day-19/cats).
 
 🎉 CONGRATULATIONS ! 🎉


### PR DESCRIPTION
The text for the `a single cat` API link showed up with the link included like the below image rather than just having the text. This PR fixes just that. This pull request fixes #92.

![image](https://user-images.githubusercontent.com/63827830/108655485-5b8c5180-748f-11eb-9f85-8d7db6b35c3d.png)
