### PR TITLE
Fix wrong array function in Day_01 in 11.8 Functional Programming

### DIFF
--- a/01_Day_JavaScript_Refresher/01_javascript_refresher.md
+++ b/01_Day_JavaScript_Refresher/01_javascript_refresher.md
@@ -3770,8 +3770,8 @@ console.log(allAreEven) // false
 console.log(allAreOdd)  // false
 
 const evens = [0, 2, 4, 6, 8, 10]
-const someAreEvens = evens.some((n) => n % 2 === 0)
-const someAreOdds = evens.some((n) => n % 2 !== 0)
+const someAreEvens = evens.every((n) => n % 2 === 0)
+const someAreOdds = evens.every((n) => n % 2 !== 0)
 
 console.log(someAreEvens) // true
 console.log(someAreOdds)  // false


### PR DESCRIPTION
Second example should be every instead of some.

```js

...
...
...

const evens = [0, 2, 4, 6, 8, 10]
const someAreEvens = evens.every((n) => n % 2 === 0)
const someAreOdds = evens.every((n) => n % 2 !== 0)

console.log(someAreEvens) // true
console.log(someAreOdds)  // false
```