### PR TITLE
Fix wrong comments in  01_Day_JavaScript_Refresher/6.Scope/Local scope

### DIFF
--- a/01_Day_JavaScript_Refresher/01_javascript_refresher.md
+++ b/01_Day_JavaScript_Refresher/01_javascript_refresher.md
@@ -1672,7 +1672,7 @@ function letsLearnScope() {
     let d = 40
     console.log(a, b, c) // Python 20 30
   }
-  // we can not access c because c's scope is only the if block
+  // we can not access d because d's scope is only the if block
   console.log(a, b) // JavaScript 10
 }
 letsLearnScope()


### PR DESCRIPTION
wrong comments in letsLearnScope function
```js
function letsLearnScope() {
  console.log(a, b) // JavaScript 10, accessible
  let c = 30
  if (true) {
    // we can access from the function and outside the function but
    // variables declared inside the if will not be accessed outside the if block
    let a = 'Python'
    let b = 20
    let d = 40
    console.log(a, b, c) // Python 20 30
  }
  console.log(a,b,c)  // JavaScript 10 30
  console.log(a,b,d)  // we can not access d because d's scope is only the if block
}
letsLearnScope()
```

