### PR TITLE
patch broken links in the bottom navigation

### DIFF
--- a/04_Day_Components/04_components.md
+++ b/04_Day_Components/04_components.md
@@ -517,4 +517,4 @@ ReactDOM.render(<HexaColor />, rootElement)
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 3](../30-Days-Of-React/03_Day_Setting_Up/03_setting_up.md) | [Day 5 >>](../05_Day_Props/05_props.md)
+[<< Day 3](../03_Day_Setting_Up/03_setting_up.md) | [Day 5 >>](../05_Day_Props/05_props.md)

--- a/05_Day_Props/05_props.md
+++ b/05_Day_Props/05_props.md
@@ -1096,4 +1096,4 @@ We will cover propTypes in detail in other sections.
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 4](../04_Day_Component/04_components.md) | [Day 6 >>](../06_Day_Map_List_Keys/06_map_list_keys.md)
+[<< Day 4](../04_Day_Components/04_components.md) | [Day 6 >>](../06_Day_Map_List_Keys/06_map_list_keys.md)

--- a/13_Day_Controlled_Versus_Uncontrolled_Input/13_uncontrolled_input.md
+++ b/13_Day_Controlled_Versus_Uncontrolled_Input/13_uncontrolled_input.md
@@ -174,4 +174,4 @@ Most of the time we use controlled input instead of uncontrolled input. In case 
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 12](../12_Day_Forms/12_forms.md) | [Day 14 >>]()
+[<< Day 12](../12_Day_Forms/12_forms.md) | [Day 14 >>](../14_Day_Component_Life_Cycles/14_component_life_cycles.md)

--- a/15_Third_Party_Packages/15_third_party_packages.md
+++ b/15_Third_Party_Packages/15_third_party_packages.md
@@ -448,4 +448,4 @@ Try to also learn how to use the package _classnames_ and _validator_.
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 14](../14_Day_Component_Life_Cycles/14_component_life_cycles.md) | [Day 16 >>]()
+[<< Day 14](../14_Day_Component_Life_Cycles/14_component_life_cycles.md) | [Day 16 >>](../16_Higher_Order_Component/16_higher_order_component.md)

--- a/17_React_Router/17_react_router.md
+++ b/17_React_Router/17_react_router.md
@@ -1733,4 +1733,4 @@ coming
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 16](../16_Higher_Order_Component/16_higher_order_component.md) | [Day 18 >>](../18_projects/18_projects.md)
+[<< Day 16](../16_Higher_Order_Component/16_higher_order_component.md) | [Day 18 >>](../18_Fetch_And_Axios/18_fetch_axios.md)

--- a/18_Fetch_And_Axios/18_fetch_axios.md
+++ b/18_Fetch_And_Axios/18_fetch_axios.md
@@ -443,4 +443,4 @@ As you have seen, there is no much difference between fetch and axios. But I rec
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 17](../17_React_Router/17_react_router.md) | [Day 19>>]()
+[<< Day 17](../17_React_Router/17_react_router.md) | [Day 19>>](../19_projects/19_projects.md)

--- a/19_projects/19_projects.md
+++ b/19_projects/19_projects.md
@@ -35,4 +35,4 @@ Your result should look like this [demo](https://www.30daysofreact.com/day-19/ca
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 18](../18_Fetch_And_Axios/18_fetch_axios.md) | [Day 20>>]()
+[<< Day 18](../18_Fetch_And_Axios/18_fetch_axios.md) | [Day 20>>](../20_projects/20_projects.md)

--- a/20_projects/20_projects.md
+++ b/20_projects/20_projects.md
@@ -35,4 +35,4 @@ Your result should look like this [demo](https://www.30daysofreact.com/day-20/ca
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 19](../19_projects/19_projects.md) | [Day 21>>]()
+[<< Day 19](../19_projects/19_projects.md) | [Day 21 >>](../21_Introducing_Hooks/21_introducing_hooks.md)

--- a/21_Introducing_Hooks/21_introducing_hooks.md
+++ b/21_Introducing_Hooks/21_introducing_hooks.md
@@ -404,4 +404,4 @@ ReactDOM.render(<App />, rootElement)
 Convert everything you wrote to React hooks.
 
 🎉 CONGRATULATIONS ! 🎉
-[<< Day 20](../20_projects/20_projects.md) | [Day 22>>]()
+[<< Day 20](../20_projects/20_projects.md) | [Day 22>>](../22_Form_Using_Hooks/22_form_using_hooks.md)

--- a/27_Ref/27_ref.md
+++ b/27_Ref/27_ref.md
@@ -141,4 +141,4 @@ ReactDOM.render(<App />, rootElement
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 25](../25_Custom_Hooks/25_custom_hooks.md) | [Day 27>>]()
+[<< Day 26](../26_Context/26_context.md) | [Day 28 >>](../28_project/28_project.md)

--- a/28_project/28_project.md
+++ b/28_project/28_project.md
@@ -33,4 +33,4 @@ In this section, you and I will develop an old version of twitter post.
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 27](../27_Ref/27_ref.md) | [Day 29>>]()
+[<< Day 27](../27_Ref/27_ref.md) | [Day 29>>](../29_explore/29_explore.md)

--- a/29_explore/29_explore.md
+++ b/29_explore/29_explore.md
@@ -39,4 +39,4 @@ Coming ...
 
 🎉 CONGRATULATIONS ! 🎉
 
-[<< Day 27](../27_Ref/27_ref.md) | [Day 29>>]()
+[<< Day 28](../28_project/28_project.md) | [Day 30 >>](../30_conclusions/30_conclusions.md)


### PR DESCRIPTION
## :balloon: This PR Resolves the Following Issues: 
 - Broken previous-day link in **Day 04 & 05** markdown files
 - Broken next-day link in **Day 13, 15, 17, 18, 19, 20, 21 & 28** markdown files
 - Wrong day numbers in the **'prev' and 'next' links** of **Day 27 & 29** markdown files
 - No line break in **Day 26** markdown file