### PR TITLE
Fix splice mistake in day1

### DIFF
--- a/01_Day_JavaScript_Refresher/01_javascript_refresher.md
+++ b/01_Day_JavaScript_Refresher/01_javascript_refresher.md
@@ -788,8 +788,8 @@ Splice: It takes three parameters:Starting position, number of times to be remov
 
 ```js
 const numbers = [1, 2, 3, 4, 5]
-
-console.log(numbers.splice()) // -> remove all items
+numbers.splice(0, numbers.length) // -> remove all items
+console.log(numbers)
 ```
 
 ```js

--- a/01_Day_JavaScript_Refresher/01_javascript_refresher.md
+++ b/01_Day_JavaScript_Refresher/01_javascript_refresher.md
@@ -789,17 +789,19 @@ Splice: It takes three parameters:Starting position, number of times to be remov
 ```js
 const numbers = [1, 2, 3, 4, 5]
 numbers.splice(0, numbers.length) // -> remove all items
-console.log(numbers)
+console.log(numbers) // -> []
 ```
 
 ```js
 const numbers = [1, 2, 3, 4, 5]
-console.log(numbers.splice(0, 1)) // remove the first item
+numbers.splice(0, 1) // remove the first item
+console.log(numbers) // -> [2, 3, 4, 5]
 ```
 
 ```js
 const numbers = [1, 2, 3, 4, 5, 6]
-console.log(numbers.splice(3, 3, 7, 8, 9)) // -> [1, 2, 3, 7, 8, 9] //it removes three item and replace three items
+numbers.splice(3, 3, 7, 8, 9) // it removes three item and replace three items
+console.log(numbers) // -> [1, 2, 3, 7, 8, 9]
 ```
 
 ##### Adding item to an array using push


### PR DESCRIPTION
## Summary

This PR addresses a minor mistake made in the "Splice method in array" section in Day 1, as well as restructures some code for clarity.

### Mistake with removing all elements using `splice`
Originally, the Day 1 tutorial claimed that the following code would remove all items:
```javascript
const numbers = [1, 2, 3, 4, 5]
console.log(numbers.splice())
```
While `numbers.splice()` does return an empty list, it does not remove any items from `numbers`.

This can be seen in [this demo](https://jsfiddle.net/275n9Ltp/).

### Printing contents of `numbers`
As a corollary, it would be more informative to print the actual contents of `numbers` rather than the return values of the methods called on `numbers`, especially because `splice` modifies the array in-place.
```javascript
// print return value of splice
console.log(numbers.splice(0, 1));

// print actual contents of spliced array
numbers.splice(0, 1);
console.log(numbers);
```