### PR TITLE
Fixed Broken Boiler Plate Link in MD file - Day 03

### DIFF
--- a/03_Day_Setting_Up/03_setting_up.md
+++ b/03_Day_Setting_Up/03_setting_up.md
@@ -734,7 +734,7 @@ ReactDOM.render(app, rootElement)
 
 ![All JSX together final](../images/all_jsx_final.png)
 
-The boilerplate code can be found [here](../03/../03_Day_Setting_Up/30-days-of-react_boilerplate)
+The boilerplate code can be found [here](03_Day_Setting_Up/03_setting_up_boilerplate)
 
 # Exercises
 

--- a/03_Day_Setting_Up/03_setting_up.md
+++ b/03_Day_Setting_Up/03_setting_up.md
@@ -734,7 +734,7 @@ ReactDOM.render(app, rootElement)
 
 ![All JSX together final](../images/all_jsx_final.png)
 
-The boilerplate code can be found [here](../03_Day_Setting_Up/03_setting_up_boilerplate)
+The boilerplate code can be found [here](../03_setting_up_boilerplate)
 
 # Exercises
 

--- a/03_Day_Setting_Up/03_setting_up.md
+++ b/03_Day_Setting_Up/03_setting_up.md
@@ -734,7 +734,7 @@ ReactDOM.render(app, rootElement)
 
 ![All JSX together final](../images/all_jsx_final.png)
 
-The boilerplate code can be found [here](03_Day_Setting_Up/03_setting_up_boilerplate)
+The boilerplate code can be found [here](../03_Day_Setting_Up/03_setting_up_boilerplate)
 
 # Exercises
 

--- a/03_Day_Setting_Up/03_setting_up.md
+++ b/03_Day_Setting_Up/03_setting_up.md
@@ -734,7 +734,7 @@ ReactDOM.render(app, rootElement)
 
 ![All JSX together final](../images/all_jsx_final.png)
 
-The boilerplate code can be found [here](../03_setting_up_boilerplate)
+The boilerplate code can be found [here](../03/../03_Day_Setting_Up/03_setting_up_boilerplate)
 
 # Exercises
 


### PR DESCRIPTION
The link in the day 3 markdown file (```03_setting_up.md```) to the boiler plate code was pointing to a resource/link that was no longer valued.

Corrected the link to point to ```03_setting_up_boilerplate``` directory instead of``` ../03/../03_Day_Setting_Up/30-days-of-react_boilerplate```