### PR TITLE
Fix typo in index

### DIFF
--- a/01_Day_JavaScript_Refresher/01_javascript_refresher.md
+++ b/01_Day_JavaScript_Refresher/01_javascript_refresher.md
@@ -85,7 +85,7 @@
     - [Local scope](#local-scope)
   - [7. Object](#7-object)
     - [Creating an empty object](#creating-an-empty-object)
-    - [Creating an objecting with values](#creating-an-objecting-with-values)
+    - [Creating an object with values](#creating-an-objecting-with-values)
     - [Getting values from an object](#getting-values-from-an-object)
     - [Creating object methods](#creating-object-methods)
     - [Setting new key for an object](#setting-new-key-for-an-object)


### PR DESCRIPTION
This commit fixes a typo in the index file of the 30 Days of React project. The typo was in the line "Creating an objecting with values", which should be "Creating an object with values". This correction improves the readability and clarity of the instructions for the learners. No other changes were made to the file or the project.