### PR TITLE
Typo at 14-component life cycles

### DIFF
--- a/14_Day_Component_Life_Cycles/14_component_life_cycles.md
+++ b/14_Day_Component_Life_Cycles/14_component_life_cycles.md
@@ -95,7 +95,7 @@ const rootElement = document.getElementById('root')
 ReactDOM.render(<App />, rootElement)
 ```
 
-### Contructor
+### Constructor
 
 Nowadays we write class based-component without a constructor and we can write the state also outside the constructor. In older version React we the state used be always inside the constructor.
 


### PR DESCRIPTION
I found a typo in the component life cycles md file where the Constructor was types Contructor